### PR TITLE
MacCompatibleUpdate - Unix style file path separators

### DIFF
--- a/SubnauticaModSystem/AutosortLockers/Mod.cs
+++ b/SubnauticaModSystem/AutosortLockers/Mod.cs
@@ -30,7 +30,7 @@ namespace AutosortLockers
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			AddBuildables();
@@ -49,17 +49,17 @@ namespace AutosortLockers
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/AutosortLockers/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/AutosortLockers/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\AutosortLockers");
+			Mod.Patch("QMods/AutosortLockers");
 		}
 	}
 }

--- a/SubnauticaModSystem/BaseTeleporters/Mod.cs
+++ b/SubnauticaModSystem/BaseTeleporters/Mod.cs
@@ -24,7 +24,7 @@ namespace BaseTeleporters
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			HarmonyInstance harmony = HarmonyInstance.Create("com.BaseTeleporters.mod");
@@ -37,17 +37,17 @@ namespace BaseTeleporters
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/BaseTeleporters/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/BaseTeleporters/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\BaseTeleporters");
+			Mod.Patch("QMods/BaseTeleporters");
 		}
 	}
 }

--- a/SubnauticaModSystem/BetterPowerInfo/Mod.cs
+++ b/SubnauticaModSystem/BetterPowerInfo/Mod.cs
@@ -20,7 +20,7 @@ namespace BetterPowerInfo
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			HarmonyInstance harmony = HarmonyInstance.Create("com.betterpowerinfo.mod");
@@ -31,7 +31,7 @@ namespace BetterPowerInfo
 
 		private static string GetModInfoPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory + "\\mod.json";
+			return Environment.CurrentDirectory + "/" + modDirectory + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/BetterPowerInfo/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/BetterPowerInfo/ModLoaderIntegration.cs
@@ -10,7 +10,7 @@ namespace BetterPowerInfo
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\BetterPowerInfo");
+			Mod.Patch("QMods/BetterPowerInfo");
 		}
 	}
 }

--- a/SubnauticaModSystem/BetterScannerBlips/Mod.cs
+++ b/SubnauticaModSystem/BetterScannerBlips/Mod.cs
@@ -19,7 +19,7 @@ namespace BetterScannerBlips
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			HarmonyInstance harmony = HarmonyInstance.Create("com.BetterScannerBlips.mod");
@@ -32,17 +32,17 @@ namespace BetterScannerBlips
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/BetterScannerBlips/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/BetterScannerBlips/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\BetterScannerBlips");
+			Mod.Patch("QMods/BetterScannerBlips");
 		}
 	}
 }

--- a/SubnauticaModSystem/BlueprintTracker/Mod.cs
+++ b/SubnauticaModSystem/BlueprintTracker/Mod.cs
@@ -24,7 +24,7 @@ namespace BlueprintTracker
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			HarmonyInstance harmony = HarmonyInstance.Create("com.blueprinttracker.mod");
@@ -35,17 +35,17 @@ namespace BlueprintTracker
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		public static int GetMaxPins()

--- a/SubnauticaModSystem/BlueprintTracker/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/BlueprintTracker/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\BlueprintTracker");
+			Mod.Patch("QMods/BlueprintTracker");
 		}
 	}
 }

--- a/SubnauticaModSystem/CustomPings/Mod.cs
+++ b/SubnauticaModSystem/CustomPings/Mod.cs
@@ -28,7 +28,7 @@ namespace CustomBeacons
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			HarmonyInstance harmony = HarmonyInstance.Create("com.CustomBeacons.mod");
@@ -63,17 +63,17 @@ namespace CustomBeacons
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/CustomPings/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/CustomPings/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\CustomBeacons");
+			Mod.Patch("QMods/CustomBeacons");
 		}
 	}
 }

--- a/SubnauticaModSystem/CustomizedStorage/Mod.cs
+++ b/SubnauticaModSystem/CustomizedStorage/Mod.cs
@@ -16,7 +16,7 @@ namespace CustomizedStorage
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			HarmonyInstance harmony = HarmonyInstance.Create("com.CustomizedStorage.mod");
@@ -27,17 +27,17 @@ namespace CustomizedStorage
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetConfigPath()
 		{
-			return GetModPath() + "\\config.json";
+			return GetModPath() + "/config.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/CustomizedStorage/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/CustomizedStorage/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\CustomizedStorage");
+			Mod.Patch("QMods/CustomizedStorage");
 		}
 	}
 }

--- a/SubnauticaModSystem/DockedVehicleStorageAccess/Mod.cs
+++ b/SubnauticaModSystem/DockedVehicleStorageAccess/Mod.cs
@@ -24,7 +24,7 @@ namespace DockedVehicleStorageAccess
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			AddBuildables();
@@ -42,17 +42,17 @@ namespace DockedVehicleStorageAccess
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/DockedVehicleStorageAccess/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/DockedVehicleStorageAccess/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\DockedVehicleStorageAccess");
+			Mod.Patch("QMods/DockedVehicleStorageAccess");
 		}
 	}
 }

--- a/SubnauticaModSystem/HabitatControlPanel/Mod.cs
+++ b/SubnauticaModSystem/HabitatControlPanel/Mod.cs
@@ -25,7 +25,7 @@ namespace HabitatControlPanel
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			AddBuildables();
@@ -44,17 +44,17 @@ namespace HabitatControlPanel
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/HabitatControlPanel/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/HabitatControlPanel/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\HabitatControlPanel");
+			Mod.Patch("QMods/HabitatControlPanel");
 		}
 	}
 }

--- a/SubnauticaModSystem/HudConfig/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/HudConfig/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\HudConfig");
+			Mod.Patch("QMods/HudConfig");
 		}
 	}
 }

--- a/SubnauticaModSystem/LongLockerNames/Mod.cs
+++ b/SubnauticaModSystem/LongLockerNames/Mod.cs
@@ -15,7 +15,7 @@ namespace LongLockerNames
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			HarmonyInstance harmony = HarmonyInstance.Create("com.LongLockerNames.mod");
@@ -26,17 +26,17 @@ namespace LongLockerNames
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/LongLockerNames/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/LongLockerNames/ModLoaderIntegration.cs
@@ -7,7 +7,7 @@ namespace LongLockerNames
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\LongLockerNames");
+			Mod.Patch("QMods/LongLockerNames");
 		}
 	}
 }

--- a/SubnauticaModSystem/ModInjector_MoreQuickSlots/Form1.cs
+++ b/SubnauticaModSystem/ModInjector_MoreQuickSlots/Form1.cs
@@ -13,10 +13,10 @@ namespace ModInjector_MoreQuickSlots
 {
 	public partial class Form1 : Form
 	{
-		private const string steamInstallRegistryPath = @"HKEY_LOCAL_MACHINE\SOFTWARE\Valve\Steam";
+		private const string steamInstallRegistryPath = "HKEY_LOCAL_MACHINE/SOFTWARE/Valve/Steam";
 		private const string steamInstallRegistryKey = "InstallPath";
-		private const string steamConfigFile = @"\config\config.vdf";
-		private const string subnauticaDir = @"\steamapps\common\Subnautica";
+		private const string steamConfigFile = "/config/config.vdf";
+		private const string subnauticaDir = "/steamapps/common/Subnautica";
 		private const string steamConfigBaseInstallKey = "BaseInstallFolder_";
 
 		private Injector injector;
@@ -51,7 +51,7 @@ namespace ModInjector_MoreQuickSlots
 					{
 						int start = line.LastIndexOf("\t\t\"") + 3;
 						string dir = line.Substring(start, line.Length - start - 1);
-						dir = dir.Replace("\\\\", "\\");
+						dir = dir.Replace("//", "/");
 						potentialDirectories.Add(dir + subnauticaDir);
 					}
 				}

--- a/SubnauticaModSystem/ModInjector_MoreQuickSlots/Injector.cs
+++ b/SubnauticaModSystem/ModInjector_MoreQuickSlots/Injector.cs
@@ -24,7 +24,7 @@ namespace ModInjector_MoreQuickSlots
 	{
 		private const string mainFilename = "Assembly-CSharp.dll";
 		private const string backupFilename = "Assembly-CSharp.rk_original.dll";
-		private const string subnauticaManagedDir = @"\Subnautica_Data\Managed\";
+		private const string subnauticaManagedDir = "/Subnautica_Data/Managed/";
 		private const string mainPatchingClass = "GameInput";
 		private const string mainPatchingMethod = "Awake";
 

--- a/SubnauticaModSystem/MoreQuickSlots/Mod.cs
+++ b/SubnauticaModSystem/MoreQuickSlots/Mod.cs
@@ -19,7 +19,7 @@ namespace MoreQuickSlots
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			keys[5] = config.Slot6Key;
@@ -38,7 +38,7 @@ namespace MoreQuickSlots
 
 		private static string GetModInfoPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory + "\\mod.json";
+			return Environment.CurrentDirectory + "/" + modDirectory + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/MoreQuickSlots/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/MoreQuickSlots/ModLoaderIntegration.cs
@@ -11,7 +11,7 @@ namespace MoreQuickSlots
 	{
 		public static void Patch()
 		{
-			Mod.Patch("Subnautica_Data\\Managed");
+			Mod.Patch("Subnautica_Data/Managed");
 		}
 	}
 
@@ -20,7 +20,7 @@ namespace MoreQuickSlots
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\MoreQuickSlots");
+			Mod.Patch("QMods/MoreQuickSlots");
 		}
 	}
 
@@ -34,7 +34,7 @@ namespace MoreQuickSlots
 		{
 			Logger.Log("Mod Loaded by Nexus ModLoader (" + obj.path + ")");
 			Controller.entry = obj;
-			Mod.Patch("Subnautica_Data\\Mods\\MoreQuickSlots");
+			Mod.Patch("Subnautica_Data/Mods/MoreQuickSlots");
 		}
 	}*/
 
@@ -55,7 +55,7 @@ namespace MoreQuickSlots
 		public override void Patch()
 		{
 			Logger.Log("Mod Loaded by SubnauticaModLoader by dumbdiscord");
-			Mod.Patch("Mods\\MoreQuickSlots");
+			Mod.Patch("Mods/MoreQuickSlots");
 		}
 	}*/
 }

--- a/SubnauticaModSystem/PrawnsuitLightswitch/Mod.cs
+++ b/SubnauticaModSystem/PrawnsuitLightswitch/Mod.cs
@@ -13,7 +13,7 @@ namespace PrawnsuitLightswitch
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			HarmonyInstance harmony = HarmonyInstance.Create("com.PrawnsuitLightswitch.mod");
@@ -24,17 +24,17 @@ namespace PrawnsuitLightswitch
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/PrawnsuitLightswitch/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/PrawnsuitLightswitch/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\PrawnsuitLightswitch");
+			Mod.Patch("QMods/PrawnsuitLightswitch");
 		}
 	}
 }

--- a/SubnauticaModSystem/SeaglideMapMod/Mod.cs
+++ b/SubnauticaModSystem/SeaglideMapMod/Mod.cs
@@ -13,7 +13,7 @@ namespace SeaglideMapControls
 
 		public static void Patch(string modDirectory = null)
 		{
-			Mod.modDirectory = modDirectory ?? "Subnautica_Data\\Managed";
+			Mod.modDirectory = modDirectory ?? "Subnautica_Data/Managed";
 			LoadConfig();
 
 			HarmonyInstance harmony = HarmonyInstance.Create("com.SeaglideMapControls.mod");
@@ -24,17 +24,17 @@ namespace SeaglideMapControls
 
 		public static string GetModPath()
 		{
-			return Environment.CurrentDirectory + "\\" + modDirectory;
+			return Environment.CurrentDirectory + "/" + modDirectory;
 		}
 
 		public static string GetAssetPath(string filename)
 		{
-			return GetModPath() + @"\Assets\" + filename;
+			return GetModPath() + "/Assets/" + filename;
 		}
 
 		private static string GetModInfoPath()
 		{
-			return GetModPath() + "\\mod.json";
+			return GetModPath() + "/mod.json";
 		}
 
 		private static void LoadConfig()

--- a/SubnauticaModSystem/SeaglideMapMod/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/SeaglideMapMod/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\SeaglideMapControls");
+			Mod.Patch("QMods/SeaglideMapControls");
 		}
 	}
 }

--- a/SubnauticaModSystem/TorpedoImprovements/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/TorpedoImprovements/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\TorpedoImprovements");
+			Mod.Patch("QMods/TorpedoImprovements");
 		}
 	}
 }

--- a/SubnauticaModSystem/WhiteLights/ModLoaderIntegration.cs
+++ b/SubnauticaModSystem/WhiteLights/ModLoaderIntegration.cs
@@ -5,7 +5,7 @@
 	{
 		public static void Patch()
 		{
-			Mod.Patch("QMods\\WhiteLights");
+			Mod.Patch("QMods/WhiteLights");
 		}
 	}
 }


### PR DESCRIPTION
Replaces back slashes in all file paths in the source code with forward slashes for compatibility with non-Windows machines